### PR TITLE
move mobilecoin submodule to the official repo and grab the current release/v6.0 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mobilecoin"]
 	path = mobilecoin
-	url = git@github.com:cbeck88/mobilecoin.git
+	url = git@github.com:mobilecoinfoundation/mobilecoin.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN  mkdir -p ${RUSTUP_HOME} \
 
 # Install rustup
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-  sh -s -- -y --default-toolchain nightly-2023-01-22
+  sh -s -- -y --default-toolchain nightly-2023-10-01
 
 ENV PATH=/opt/cargo/bin:$PATH
 


### PR DESCRIPTION
This will require a small change in our main repo:
```
diff --git a/rust/util/mobilecoin/proto/mobilecoind_api.proto b/rust/util/mobilecoin/proto/mobilecoind_api.proto
index fe589cc9..06137cad 100644
--- a/rust/util/mobilecoin/proto/mobilecoind_api.proto
+++ b/rust/util/mobilecoin/proto/mobilecoind_api.proto
@@ -175,8 +175,8 @@ message DecodedMemo {
     // Details of the decoded memo payload.
     // Omitted if the empty memo was found.
     oneof decoded_memo {
-      AuthenticatedSenderMemo authenticated_sender_memo = 1;
-      UnknownMemo unknown_memo = 2;
+      UnknownMemo unknown_memo = 1;
+      AuthenticatedSenderMemo authenticated_sender_memo = 2;
     }
 }
```

This means that stored utxo data in the mobilecoin wallet db will not have the right memo information, but I don't think it matters since we only look at it when new deposits arrive, so as long as we transition when we don't have in-flight deposits, we won't notice this change.

In-flight deposits in-flight when this change is happening will get RTH-flagged (which has no impact on the customer right now). The only place where this will be a problem is for matching FireBot deposits, but the bot sees so little activity I think we'll be fine.

If we're not okay with it we could in theory delete the mobilecoind wallet db and have it re-scan the database...

I looked at the diff between the branch we had the submodule pointing at and the release/v6.0 branch and didn't notice any other differences that could affect us. To further confirm it doesn't break things I tested it locally and looked at the RTH stuff (but have not tested FireBot)